### PR TITLE
Hotfix/fix model regex validation

### DIFF
--- a/DelegationSharedLibrary/Models/Device.cs
+++ b/DelegationSharedLibrary/Models/Device.cs
@@ -15,7 +15,7 @@ namespace DelegationStationShared.Models
 
         [Required(AllowEmptyStrings = false, ErrorMessage = "Model is Required")]
 
-        [RegularExpression(@"^[a-zA-Z0-9\-_.,&\(\)\s]+$", ErrorMessage = "Only use letters, numbers, or the following special characters: -_&().,")]
+        [RegularExpression(@"^[a-zA-Z0-9\-_.,&\(\)+\s]+$", ErrorMessage = "Only use letters, numbers, or the following special characters: -_&().+,")]
         public string Model { get; set; }
 
 

--- a/DelegationSharedLibrary/Models/DeviceBulk.cs
+++ b/DelegationSharedLibrary/Models/DeviceBulk.cs
@@ -11,7 +11,7 @@ namespace DelegationStationShared.Models
 
         [Required(AllowEmptyStrings = false)]
 
-        [RegularExpression(@"^[a-zA-Z0-9\-_.,&\(\)\s]+$", ErrorMessage = "For model, only use letters, numbers, or the following special characters: -_&().,")]
+        [RegularExpression(@"^[a-zA-Z0-9\-_.,&\(\)+\s]+$", ErrorMessage = "For model, only use letters, numbers, or the following special characters: -_&().+,")]
         public string Model { get; set; }
 
 

--- a/tools/speedUpOldStraggers
+++ b/tools/speedUpOldStraggers
@@ -5,7 +5,7 @@
 //
 //  The scenario where this is needed is:
 //  UpdatedDevices is run manually to ensure pickup of devices enrolled earlier.
-//  Stragglers will have entries creaated, but they won't get processed by 
+//  Stragglers will have entries created, but they won't get processed by 
 //  UpdateDevices again without manual intervention.
 //  This script prevents requiring additional manual runs of UpdateDevices.
 //


### PR DESCRIPTION
Users reported not being able to add Surface Pro 7+ devices after the last deploy.
Identified the issue is that I copy/pasted the regex from make/model to add the command and deleted the "+" character from the model field.  